### PR TITLE
Improve error handling on unmatched routes

### DIFF
--- a/example/lib/example.ex
+++ b/example/lib/example.ex
@@ -1,10 +1,7 @@
 defmodule Example do
-  import Plug.BasicAuth
-
   use Francis,
     plugs: [
-      Plug.Logger,
-      {:basic_auth, username: "test", password: "test"}
+      Plug.Logger
     ]
 
   get("/", fn _ ->

--- a/lib/francis.ex
+++ b/lib/francis.ex
@@ -17,7 +17,7 @@ defmodule Francis do
     quote location: :keep do
       use Application
 
-      def start(), do: start(nil, nil)
+      def start, do: start(nil, nil)
 
       def start(_type, _args) do
         children = [

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -8,6 +8,7 @@ defmodule Francis.Plug.Router do
   defmacro __using__(opts) do
     quote location: :keep do
       import Francis
+      require Logger
 
       @plug_router_to %{}
       @before_compile Plug.Router
@@ -18,6 +19,10 @@ defmodule Francis.Plug.Router do
       @doc false
       def match(conn, _opts) do
         do_match(conn, conn.method, Utils.decode_path_info!(conn), conn.host)
+      rescue
+        err ->
+          Logger.error("Failed to match route: #{conn.method} #{conn.request_path}")
+          conn |> send_resp(404, "Not Found") |> halt()
       end
 
       @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Francis.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
 
   def project do
     [

--- a/test/francis_test.exs
+++ b/test/francis_test.exs
@@ -1,7 +1,8 @@
 defmodule FrancisTest do
   use ExUnit.Case
-  doctest Francis
-  require Francis
+
+  import ExUnit.CaptureLog
+
   alias Francis
 
   describe "get/1" do
@@ -100,6 +101,15 @@ defmodule FrancisTest do
 
       mod = Support.RouteTester.generate_module(handler, [plug1, plug2])
       assert Req.get!("/", plug: mod).body == ["plug1", "plug2"]
+    end
+  end
+
+  describe "non matching routes without unmatched handler" do
+    test "returns an log error with the method and path of the failed route" do
+      mod = Support.RouteTester.generate_module(quote do: get("/", fn _ -> "test" end))
+
+      assert capture_log(fn -> Req.get!("/not_here", plug: mod) end) =~
+               "Failed to match route: GET /not_here"
     end
   end
 end


### PR DESCRIPTION
Currently we were getting a really bad match error. This captures that error and sanitizes it into something cleaner and easier to work with.