### PR TITLE
feat: add SSE (Server-Sent Events) support

### DIFF
--- a/lib/francis.ex
+++ b/lib/francis.ex
@@ -292,15 +292,17 @@ defmodule Francis do
     end
   end
 
-  # Private helper functions for WebSocket macro
-  defp generate_ws_module_name(path) do
+  defp path_to_module_suffix(path) do
     path
     |> URI.parse()
     |> Map.get(:path)
     |> String.split("/")
     |> Enum.map_join(".", &Macro.camelize/1)
-    |> then(&Module.concat([__MODULE__, &1]))
   end
+
+  defp generate_ws_module_name(path),
+    do: path |> path_to_module_suffix() |> then(&Module.concat([__MODULE__, &1]))
+
 
   defp build_ws_handler_ast(module_name, handler) do
     quote do
@@ -341,6 +343,129 @@ defmodule Francis do
           Francis.Websocket.cancel_heartbeat(state)
           Francis.Websocket.call_close(unquote(handler), {:close, reason}, state)
           :ok
+        end
+      end
+    end
+  end
+
+  @doc """
+  Defines a Server-Sent Events (SSE) route.
+
+  The handler function uses pattern matching on lifecycle events. The connection stays
+  open and events are streamed to the client. Messages sent to `socket.transport` are
+  automatically forwarded as SSE events.
+
+  ## Events
+
+  - `:join` - Sent when a client connects. Return `{:reply, message}` to send a welcome event.
+  - `{:close, reason}` - Sent when the connection closes. Return `:ok` or `:noreply`.
+
+  ## Return Values
+
+  - `{:reply, response}` - where `response` can be a binary, a map, or a list (maps/lists will be JSON encoded)
+  - `:noreply` or `:ok` - to not send a response
+
+  ## Socket State
+
+  The socket state map includes:
+  - `:transport` - The process pid. Send messages here to push SSE events to the client.
+  - `:id` - A unique identifier for the connection.
+  - `:path` - The actual request path.
+  - `:params` - A map of path parameters.
+
+  ## Options
+
+  - `:timeout` - How long to keep the connection open in milliseconds (default: `:infinity`)
+
+  ## Examples
+
+  ```elixir
+  defmodule Example.Router do
+    use Francis
+
+    sse "/events", fn
+      :join, socket ->
+        {:reply, %{type: "connected", id: socket.id}}
+
+      {:close, _reason}, _socket ->
+        :ok
+    end
+
+    sse "/stream/:topic", fn
+      :join, socket ->
+        topic = socket.params["topic"]
+        send(socket.transport, "subscribed to: " <> topic)
+        :noreply
+
+      {:close, _reason}, _socket ->
+        :ok
+    end
+  end
+  ```
+  """
+  @spec sse(
+          String.t(),
+          (event :: :join | {:close, term()},
+           socket :: %{id: binary(), transport: pid(), path: binary(), params: map()} ->
+             {:reply, binary() | map() | list()} | :noreply | :ok),
+          Keyword.t()
+        ) :: Macro.t()
+  defmacro sse(path, handler, opts \\ []) do
+    module_name = generate_sse_module_name(path)
+    handler_ast = build_sse_handler_ast(module_name, handler)
+    timeout = Keyword.get(opts, :timeout, :infinity)
+
+    Code.compile_quoted(handler_ast)
+
+    quote location: :keep do
+      get(unquote(path), fn conn ->
+        state = %{
+          id: 32 |> :crypto.strong_rand_bytes() |> Base.encode16(),
+          path: conn.request_path,
+          params: conn.params,
+          transport: self()
+        }
+
+        conn
+        |> put_resp_header("content-type", "text/event-stream")
+        |> put_resp_header("cache-control", "no-cache")
+        |> put_resp_header("connection", "keep-alive")
+        |> send_chunked(200)
+        |> unquote(module_name).run(state, unquote(timeout))
+      end)
+    end
+  end
+
+  defp generate_sse_module_name(path),
+    do: path |> path_to_module_suffix() |> then(&Module.concat([__MODULE__, SSE, &1]))
+
+  defp build_sse_handler_ast(module_name, handler) do
+    quote do
+      defmodule unquote(module_name) do
+        def run(conn, state, timeout) do
+          {:ok, conn, state} = Francis.SSE.call_join(unquote(handler), conn, state)
+          loop(conn, state, timeout)
+        end
+
+        defp loop(conn, state, timeout) do
+          receive do
+            msg when is_binary(msg) or is_map(msg) or is_list(msg) ->
+              case Francis.SSE.send_event(conn, msg) do
+                {:ok, conn} ->
+                  loop(conn, state, timeout)
+
+                {:error, _reason} ->
+                  Francis.SSE.call_close(unquote(handler), {:close, :disconnected}, state)
+                  conn
+              end
+
+            _other ->
+              loop(conn, state, timeout)
+          after
+            timeout ->
+              Francis.SSE.call_close(unquote(handler), {:close, :timeout}, state)
+              conn
+          end
         end
       end
     end

--- a/lib/francis/sse.ex
+++ b/lib/francis/sse.ex
@@ -1,0 +1,38 @@
+defmodule Francis.SSE do
+  @moduledoc false
+
+  def format_message(msg) when is_binary(msg) do
+    escaped = String.replace(msg, "\n", "\ndata: ")
+    "data: #{escaped}\n\n"
+  end
+
+  def format_message(msg) when is_map(msg) or is_list(msg) do
+    format_message(Jason.encode!(msg))
+  end
+
+  def send_event(conn, msg) do
+    Plug.Conn.chunk(conn, format_message(msg))
+  end
+
+  def call_join(handler, conn, state) do
+    case handler.(:join, state) do
+      {:reply, msg} ->
+        case send_event(conn, msg) do
+          {:ok, conn} -> {:ok, conn, state}
+          {:error, _} -> {:ok, conn, state}
+        end
+
+      _ ->
+        {:ok, conn, state}
+    end
+  rescue
+    _e in [MatchError, FunctionClauseError] -> {:ok, conn, state}
+  end
+
+  def call_close(handler, event, state) do
+    handler.(event, state)
+    :ok
+  rescue
+    _e in [MatchError, FunctionClauseError] -> :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -61,6 +61,7 @@ defmodule Francis.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:req, "~> 0.5", only: [:test]},
       {:websockex, "~> 0.4", only: [:test]},
+      {:mint, "~> 1.7", only: [:test]},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:sobelow, "~> 0.13", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/test/francis_test.exs
+++ b/test/francis_test.exs
@@ -1041,4 +1041,126 @@ defmodule FrancisTest do
       assert Francis.get_configuration(:test_key, [], "default") == "default"
     end
   end
+
+  describe "sse/1" do
+    setup do
+      %{port: Enum.random(10_001..20_000)}
+    end
+
+    @tag :capture_log
+    test "sends welcome message on :join", %{port: port} do
+      parent_pid = self()
+      path = 10 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+      handler =
+        quote do
+          sse(unquote(path), fn
+            :join, socket ->
+              send(unquote(parent_pid), {:handler, :join_received})
+              {:reply, "welcome"}
+
+            {:close, _reason}, _socket ->
+              :ok
+          end)
+        end
+
+      mod = Support.RouteTester.generate_module(handler, bandit_opts: [port: port])
+      {:ok, _} = start_supervised(mod)
+
+      start_supervised!(
+        {Support.SseTester, %{url: "http://localhost:#{port}/#{path}", parent_pid: parent_pid}}
+      )
+
+      assert_receive {:handler, :join_received}, 1000
+      assert_receive {:client, "welcome"}, 1000
+    end
+
+    @tag :capture_log
+    test "forwards messages sent to transport as SSE events", %{port: port} do
+      parent_pid = self()
+      path = 10 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+      handler =
+        quote do
+          sse(unquote(path), fn
+            :join, socket ->
+              send(socket.transport, "hello")
+              send(socket.transport, %{key: "value"})
+              send(socket.transport, [1, 2, 3])
+              :noreply
+
+            {:close, _reason}, _socket ->
+              :ok
+          end)
+        end
+
+      mod = Support.RouteTester.generate_module(handler, bandit_opts: [port: port])
+      {:ok, _} = start_supervised(mod)
+
+      start_supervised!(
+        {Support.SseTester, %{url: "http://localhost:#{port}/#{path}", parent_pid: parent_pid}}
+      )
+
+      assert_receive {:client, "hello"}, 1000
+      assert_receive {:client, %{"key" => "value"}}, 1000
+      assert_receive {:client, [1, 2, 3]}, 1000
+    end
+
+    @tag :capture_log
+    test "exposes socket id, path, and params", %{port: port} do
+      parent_pid = self()
+      path = 10 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+      handler =
+        quote do
+          sse(unquote(path), fn
+            :join, socket ->
+              send(unquote(parent_pid), {:socket, socket})
+              :noreply
+
+            {:close, _reason}, _socket ->
+              :ok
+          end)
+        end
+
+      mod = Support.RouteTester.generate_module(handler, bandit_opts: [port: port])
+      {:ok, _} = start_supervised(mod)
+
+      start_supervised!(
+        {Support.SseTester, %{url: "http://localhost:#{port}/#{path}", parent_pid: parent_pid}}
+      )
+
+      assert_receive {:socket, socket}, 1000
+      assert is_binary(socket.id) and byte_size(socket.id) > 0
+      assert is_pid(socket.transport)
+      assert socket.path == "/#{path}"
+    end
+
+    @tag :capture_log
+    test "calls :close handler on timeout", %{port: port} do
+      parent_pid = self()
+      path = 10 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+      handler =
+        quote do
+          sse(unquote(path), fn
+            :join, _socket ->
+              :noreply
+
+            {:close, reason}, _socket ->
+              send(unquote(parent_pid), {:handler, {:close, reason}})
+              :ok
+          end, timeout: 200)
+        end
+
+      mod = Support.RouteTester.generate_module(handler, bandit_opts: [port: port])
+      {:ok, _} = start_supervised(mod)
+
+      start_supervised!(
+        {Support.SseTester, %{url: "http://localhost:#{port}/#{path}", parent_pid: parent_pid}}
+      )
+
+      assert_receive {:handler, {:close, :timeout}}, 500
+    end
+  end
 end

--- a/test/support/sse_tester.ex
+++ b/test/support/sse_tester.ex
@@ -1,0 +1,106 @@
+defmodule Support.SseTester do
+  @moduledoc """
+  SSE client to test Francis SSE routes
+  """
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(%{url: url, parent_pid: parent_pid}) do
+    uri = URI.parse(url)
+    port = uri.port || 80
+    host = uri.host || "localhost"
+    path = uri.path || "/"
+
+    {:ok, conn} = Mint.HTTP.connect(:http, host, port, [])
+
+    {:ok, conn, request_ref} =
+      Mint.HTTP.request(conn, "GET", path, [
+        {"accept", "text/event-stream"},
+        {"cache-control", "no-cache"}
+      ], "")
+
+    {:ok, %{conn: conn, request_ref: request_ref, parent_pid: parent_pid, buffer: ""}}
+  end
+
+  def handle_info(message, state) do
+    case Mint.HTTP.stream(state.conn, message) do
+      {:ok, conn, responses} ->
+        state = Enum.reduce(responses, %{state | conn: conn}, &handle_response/2)
+        {:noreply, state}
+
+      {:error, conn, error, _responses} ->
+        send(state.parent_pid, {:client, {:error, error}})
+        {:stop, :normal, %{state | conn: conn}}
+
+      :unknown ->
+        {:noreply, state}
+    end
+  end
+
+  defp handle_response({:status, _ref, status}, state) do
+    send(state.parent_pid, {:client, {:status, status}})
+    state
+  end
+
+  defp handle_response({:headers, _ref, headers}, state) do
+    send(state.parent_pid, {:client, {:headers, headers}})
+    state
+  end
+
+  defp handle_response({:data, _ref, data}, state) do
+    buffer = state.buffer <> data
+    {events, remaining} = parse_events(buffer)
+    Enum.each(events, fn event -> send(state.parent_pid, {:client, event}) end)
+    %{state | buffer: remaining}
+  end
+
+  defp handle_response({:done, _ref}, state) do
+    send(state.parent_pid, {:client, :done})
+    state
+  end
+
+  defp handle_response({:error, _ref, error}, state) do
+    send(state.parent_pid, {:client, {:error, error}})
+    state
+  end
+
+  defp handle_response(_, state), do: state
+
+  defp parse_events(buffer) do
+    case String.split(buffer, ~r/\r?\n\r?\n/, parts: 2, trim: false) do
+      [event_data, rest] ->
+        event = parse_event(event_data)
+        {more_events, remaining} = parse_events(rest)
+        {[event | more_events], remaining}
+
+      [_incomplete] ->
+        {[], buffer}
+    end
+  end
+
+  defp parse_event(event_data) do
+    lines = String.split(event_data, "\n", trim: true)
+
+    event =
+      Enum.reduce(lines, %{data: []}, fn line, acc ->
+        case String.split(line, ":", parts: 2) do
+          ["data", data] -> %{acc | data: [String.trim_leading(data) | acc.data]}
+          _ -> acc
+        end
+      end)
+
+    data = event.data |> Enum.reverse() |> Enum.join("\n")
+
+    case Jason.decode(data) do
+      {:ok, decoded} -> decoded
+      {:error, _} -> data
+    end
+  end
+
+  def terminate(_reason, state) do
+    if state.conn, do: Mint.HTTP.close(state.conn)
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `sse/3` macro mirroring the `ws/3` API — same socket state shape (`id`, `transport`, `path`, `params`), same lifecycle events (`:join`, `{:close, reason}`), same `{:reply, msg}` / `:noreply` / `:ok` return conventions
- Messages sent to `socket.transport` are forwarded as SSE events to the client (strings sent as-is, maps/lists JSON-encoded)
- Adds `Francis.SSE` helper module with `format_message/1`, `send_event/2`, `call_join/3`, `call_close/3`
- Adds `Support.SseTester` (Mint-based GenServer) for integration testing SSE routes

## Implementation notes

- Uses selective receive (`when is_binary(msg) or is_map(msg) or is_list(msg)`) so internal Bandit/TCP messages don't crash `format_message/1`
- `timeout` option is resolved at macro-expansion time (compile-time constant) rather than on every request
- Shared `path_to_module_suffix/1` helper eliminates duplication between WS and SSE module name generators
- Explicit `:mint` test dependency added (was already transitive via `req → finch → mint`)

## Test plan

- [ ] `mix test test/francis_test.exs --only describe:"sse/1"` — 4 tests: join welcome reply, transport message forwarding (string/map/list), socket state fields, timeout-triggered close
- [ ] `mix test test/francis_test.exs` — full suite, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)